### PR TITLE
Fix 'Warning: Undefined array key 1 in WKT->parsePoint()'

### DIFF
--- a/lib/adapters/WKT.class.php
+++ b/lib/adapters/WKT.class.php
@@ -68,6 +68,10 @@ class WKT extends GeoAdapter
     if ($data_string == 'EMPTY') return new Point();
 
     $parts = explode(' ',$data_string);
+    if (!isset($parts[0]) || !isset($parts[1])) {
+      return new Point();
+    }
+
     return new Point($parts[0], $parts[1]);
   }
 


### PR DESCRIPTION
Can be triggered by passing an empty string to `WKT::parsePoint`. I triggered this issue originally by passing `POLYGON (())` to `Drupal\geofield\Plugin\Validation\Constraint\GeoConstraintValidator`.