### PR TITLE
Fix 'TypeError: is_nan(): Argument #1 ($num) must be of type float, string given'

### DIFF
--- a/lib/geometry/Point.class.php
+++ b/lib/geometry/Point.class.php
@@ -20,7 +20,7 @@ class Point extends Geometry
   public function __construct($x = NULL, $y = NULL, $z = NULL) {
 
     // Check if it's an empty point
-    if (($x === NULL || is_nan($x)) && ($y === NULL || is_nan($y))) {
+    if ($x === NULL && $y === NULL) {
       $this->coords = array(NULL, NULL);
       $this->dimension = 0;
       return;
@@ -43,6 +43,13 @@ class Point extends Geometry
     $x = floatval($x);
     $y = floatval($y);
     $z = floatval($z);
+
+    // Check if it's NAN
+    if (is_nan($x) && is_nan($y)) {
+      $this->coords = array(NULL, NULL);
+      $this->dimension = 0;
+      return;
+    }
 
     // Add poitional elements
     if ($this->dimension == 2) {


### PR DESCRIPTION
https://github.com/phayes/geoPHP/pull/187 introduced an issue when passing strings to the `Point` constructor, which is valid since the `$x`, `$y` and `$z` argument are typed as `numeric`. `is_nan()` expects float arguments, so we should cast strings to floats before using that function.