### PR TITLE
Fix 'round(): Argument #2 ($precision) must be of type int, float given'

### DIFF
--- a/lib/adapters/GeoHash.class.php
+++ b/lib/adapters/GeoHash.class.php
@@ -215,8 +215,8 @@ class GeoHash extends GeoAdapter{
     $ll['minlon'] = $minlon;
     $ll['maxlat'] = $maxlat;
     $ll['maxlon'] = $maxlon;
-    $ll['medlat'] = round(($minlat+$maxlat)/2, max(1, -round(log10($latE)))-1);
-    $ll['medlon'] = round(($minlon+$maxlon)/2, max(1, -round(log10($lonE)))-1);
+    $ll['medlat'] = round(($minlat+$maxlat)/2, (int) max(1, -round(log10($latE)))-1);
+    $ll['medlon'] = round(($minlon+$maxlon)/2, (int) max(1, -round(log10($lonE)))-1);
     return $ll;
   }
 


### PR DESCRIPTION
The following error is sometimes triggered when using PHP 8:

> TypeError: round(): Argument #2 ($precision) must be of type int, float given in round() (line 218 of [..]/vendor/itamair/geophp/lib/adapters/GeoHash.class.php).