### PR TITLE
Consistently use standard switch case syntax

### DIFF
--- a/lib/adapters/EWKB.class.php
+++ b/lib/adapters/EWKB.class.php
@@ -54,31 +54,31 @@ class EWKB extends WKB
     $wkb = pack('c',1);
     
     switch ($geometry->getGeomType()) {
-      case 'Point';
+      case 'Point':
         $wkb .= pack('L',1);
         $wkb .= $this->writePoint($geometry);
         break;
-      case 'LineString';
+      case 'LineString':
         $wkb .= pack('L',2);
         $wkb .= $this->writeLineString($geometry);
         break;
-      case 'Polygon';
+      case 'Polygon':
         $wkb .= pack('L',3);
         $wkb .= $this->writePolygon($geometry);
         break;
-      case 'MultiPoint';
+      case 'MultiPoint':
         $wkb .= pack('L',4);
         $wkb .= $this->writeMulti($geometry);
         break;
-      case 'MultiLineString';
+      case 'MultiLineString':
         $wkb .= pack('L',5);
         $wkb .= $this->writeMulti($geometry);
         break;
-      case 'MultiPolygon';
+      case 'MultiPolygon':
         $wkb .= pack('L',6);
         $wkb .= $this->writeMulti($geometry);
         break;
-      case 'GeometryCollection';
+      case 'GeometryCollection':
         $wkb .= pack('L',7);
         $wkb .= $this->writeMulti($geometry);
         break;

--- a/lib/adapters/WKB.class.php
+++ b/lib/adapters/WKB.class.php
@@ -162,31 +162,31 @@ class WKB extends GeoAdapter
     $wkb = pack('c',1);
 
     switch ($geometry->getGeomType()) {
-      case 'Point';
+      case 'Point':
         $wkb .= pack('L',1);
         $wkb .= $this->writePoint($geometry);
         break;
-      case 'LineString';
+      case 'LineString':
         $wkb .= pack('L',2);
         $wkb .= $this->writeLineString($geometry);
         break;
-      case 'Polygon';
+      case 'Polygon':
         $wkb .= pack('L',3);
         $wkb .= $this->writePolygon($geometry);
         break;
-      case 'MultiPoint';
+      case 'MultiPoint':
         $wkb .= pack('L',4);
         $wkb .= $this->writeMulti($geometry);
         break;
-      case 'MultiLineString';
+      case 'MultiLineString':
         $wkb .= pack('L',5);
         $wkb .= $this->writeMulti($geometry);
         break;
-      case 'MultiPolygon';
+      case 'MultiPolygon':
         $wkb .= pack('L',6);
         $wkb .= $this->writeMulti($geometry);
         break;
-      case 'GeometryCollection';
+      case 'GeometryCollection':
         $wkb .= pack('L',7);
         $wkb .= $this->writeMulti($geometry);
         break;


### PR DESCRIPTION
These were the only two switch statements using the alternate syntax. Updated them to be consistent with the rest of the project.