### PR TITLE
chore: update phpunit required version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,6 +20,6 @@
         }
     ],
     "require-dev": {
-        "phpunit/phpunit": "4.1.* || 9.5.*"
+        "phpunit/phpunit": "4.1.* || ^9.6"
     }
 }


### PR DESCRIPTION
fix "Root composer.json requires phpunit/phpunit 4.1.* || 9.5.*, found phpunit/phpunit[4.1.0, ..., 4.1.6, 9.5.0, ..., 9.5.28] but these were not loaded, because they are affected by security advisories ("PKSA-z3gr-8qht-p93v")"